### PR TITLE
feat: add server v2

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ribeirohugo/go_content_getter/internal/server"
 	"github.com/ribeirohugo/go_content_getter/pkg/config"
-	"github.com/ribeirohugo/go_content_getter/pkg/source"
 )
 
 const configFile = "config.toml"
@@ -16,9 +15,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	src := source.New(cfg.Path, cfg.ContentRegex, cfg.TitleRegex)
-
-	serverHTTP := server.New(src, src.Host)
+	serverHTTP := server.New(cfg)
 
 	err = serverHTTP.InitiateServer()
 	if err != nil {

--- a/config.toml
+++ b/config.toml
@@ -3,3 +3,4 @@ content_regex = ""
 title_regex = ""
 path = ""
 host = ""
+allowed_origins = []

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/gin-gonic/gin v1.10.1
+	github.com/ribeirohugo/go_middlewares v0.7.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/ribeirohugo/go_middlewares v0.7.2 h1:GPFxcOLE4N7l8jnvDcZ1TXFG+LJh/Cr2BKoxEFJRFZc=
+github.com/ribeirohugo/go_middlewares v0.7.2/go.mod h1:0NaMWSRW71eF3shYQ69OhCVaHVS8i8O4raE742dQCa0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/internal/server/controllers.go
+++ b/internal/server/controllers.go
@@ -32,6 +32,29 @@ func (h *HttpServer) DownloadManyHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, ContentResponse{Files: allFiles})
 }
 
+// DownloadAndStoreManyHandler handles download and store content
+func (h *HttpServer) DownloadAndStoreManyHandler(c *gin.Context) {
+	var req DownloadRequest
+	if err := c.ShouldBindJSON(&req); err != nil || len(req.URLs) == 0 {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid or missing urls in body"})
+		return
+	}
+
+	downloadSource := source.New(h.path, req.ContentPattern, req.TitlePattern)
+
+	var allFiles []model.File
+	for _, url := range req.URLs {
+		files, err := downloadSource.GetAndStore(url)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
+			return
+		}
+		allFiles = append(allFiles, files...)
+	}
+
+	c.JSON(http.StatusOK, ContentResponse{Files: allFiles})
+}
+
 // HealthHandler handles GET /api/health requests
 func (h *HttpServer) HealthHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})

--- a/internal/server/controllers.go
+++ b/internal/server/controllers.go
@@ -36,3 +36,11 @@ func (h *HttpServer) DownloadManyHandler(c *gin.Context) {
 func (h *HttpServer) HealthHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
+
+// DefaultPatternsHandler handles GET /api/default-patterns requests
+func (h *HttpServer) DefaultPatternsHandler(c *gin.Context) {
+	c.JSON(http.StatusOK, DefaultPatternsResponse{
+		ContentPattern: h.defaultRegexPattern,
+		TitlePattern:   h.defaultTitlePattern,
+	})
+}

--- a/internal/server/controllers.go
+++ b/internal/server/controllers.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ribeirohugo/go_content_getter/pkg/model"
+	"github.com/ribeirohugo/go_content_getter/pkg/source"
+)
+
+// DownloadManyHandler handles POST /api/download requests
+func (h *HttpServer) DownloadManyHandler(c *gin.Context) {
+	var req DownloadRequest
+	if err := c.ShouldBindJSON(&req); err != nil || len(req.URLs) == 0 {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid or missing urls in body"})
+		return
+	}
+
+	downloadSource := source.New(h.path, req.ContentPattern, req.TitlePattern)
+
+	var allFiles []model.File
+	for _, url := range req.URLs {
+		files, err := downloadSource.Get(url)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
+			return
+		}
+		allFiles = append(allFiles, files...)
+	}
+
+	c.JSON(http.StatusOK, ContentResponse{Files: allFiles})
+}

--- a/internal/server/controllers.go
+++ b/internal/server/controllers.go
@@ -31,3 +31,8 @@ func (h *HttpServer) DownloadManyHandler(c *gin.Context) {
 
 	c.JSON(http.StatusOK, ContentResponse{Files: allFiles})
 }
+
+// HealthHandler handles GET /api/health requests
+func (h *HttpServer) HealthHandler(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}

--- a/internal/server/model.go
+++ b/internal/server/model.go
@@ -1,0 +1,20 @@
+package server
+
+import "github.com/ribeirohugo/go_content_getter/pkg/model"
+
+// ErrorResponse represents a standard error response
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// ContentResponse represents the response for content endpoints
+type ContentResponse struct {
+	Files []model.File `json:"files"`
+}
+
+// DownloadRequest represents the request body for download content
+type DownloadRequest struct {
+	URLs           []string `json:"urls"`
+	ContentPattern string   `json:"contentPattern"`
+	TitlePattern   string   `json:"titlePattern"`
+}

--- a/internal/server/model.go
+++ b/internal/server/model.go
@@ -9,6 +9,7 @@ type ErrorResponse struct {
 
 // ContentResponse represents the response for content endpoints
 type ContentResponse struct {
+	Title string       `json:"title"`
 	Files []model.File `json:"files"`
 }
 

--- a/internal/server/model.go
+++ b/internal/server/model.go
@@ -18,3 +18,9 @@ type DownloadRequest struct {
 	ContentPattern string   `json:"contentPattern"`
 	TitlePattern   string   `json:"titlePattern"`
 }
+
+// DefaultPatternsResponse represents the response for default regex patterns
+type DefaultPatternsResponse struct {
+	ContentPattern string `json:"contentPattern"`
+	TitlePattern   string `json:"titlePattern"`
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/ribeirohugo/go_content_getter/pkg/config"
 
 	"github.com/ribeirohugo/go_content_getter/pkg/model"
 )
@@ -16,16 +17,21 @@ type Source interface {
 }
 
 type HttpServer struct {
-	path string
-	host string
-	mux  *http.ServeMux
+	host                string
+	path                string
+	defaultRegexPattern string
+	defaultTitlePattern string
+	mux                 *http.ServeMux
 }
 
 // New - HTTP server constructor
-func New(host string, path string) *HttpServer {
+func New(cfg config.Config) *HttpServer {
 	s := &HttpServer{
-		host: host,
-		mux:  http.NewServeMux(),
+		host:                cfg.Host,
+		path:                cfg.Path,
+		defaultRegexPattern: cfg.ContentRegex,
+		defaultTitlePattern: cfg.TitleRegex,
+		mux:                 http.NewServeMux(),
 	}
 
 	return s
@@ -45,6 +51,9 @@ func (h *HttpServer) InitiateServer() error {
 		// POST /api/download - download many
 		api.POST("/download", h.DownloadManyHandler)
 	}
+
+	// Health endpoint
+	api.GET("/health", h.HealthHandler)
 
 	err := router.Run(h.host)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -50,8 +50,8 @@ func (h *HttpServer) InitiateServer() error {
 	router.Use(corsMiddleware(h.allowedOrigins)) // Enables CORS using the custom middleware
 
 	// Static
-	router.Static("/assets", "./assets")
-	router.LoadHTMLFiles("templates/index.html")
+	// router.Static("/assets", "./assets")
+	// router.LoadHTMLFiles("templates/index.html")
 
 	// API group
 	api := router.Group("/api")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,8 +56,9 @@ func (h *HttpServer) InitiateServer() error {
 	// API group
 	api := router.Group("/api")
 	{
-		// POST /api/download - download many
+		// Download and Store
 		api.POST("/download", h.DownloadManyHandler)
+		api.POST("/download-and-store", h.DownloadAndStoreManyHandler)
 
 		// Health endpoint
 		api.GET("/health", h.HealthHandler)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/ribeirohugo/go_content_getter/pkg/config"
 
+	"github.com/ribeirohugo/go_content_getter/pkg/config"
 	"github.com/ribeirohugo/go_content_getter/pkg/model"
 )
 
@@ -50,10 +50,11 @@ func (h *HttpServer) InitiateServer() error {
 	{
 		// POST /api/download - download many
 		api.POST("/download", h.DownloadManyHandler)
+		// Health endpoint
+		api.GET("/health", h.HealthHandler)
+		// Default patterns endpoint
+		api.GET("/default-patterns", h.DefaultPatternsHandler)
 	}
-
-	// Health endpoint
-	api.GET("/health", h.HealthHandler)
 
 	err := router.Run(h.host)
 

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -11,11 +11,12 @@ const (
 
 // Config holds configurations data and methods
 type Config struct {
-	ContentRegex string   `toml:"content_regex"`
-	TitleRegex   string   `toml:"title_regex"`
-	Host         string   `toml:"host"`
-	Path         string   `toml:"path"`
-	URL          []string `toml:"url"`
+	ContentRegex   string   `toml:"content_regex"`
+	TitleRegex     string   `toml:"title_regex"`
+	Host           string   `toml:"host"`
+	Path           string   `toml:"path"`
+	URL            []string `toml:"url"`
+	AllowedOrigins []string `toml:"allowed_origins"`
 }
 
 // New is a Getter constructor. It requires:

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,0 @@
-{{ .message }}
-
-<form method="POST" action="/">
-    <p><input type="text" name="url_parse" style="width:100%"></p>
-    <p><input type="submit" value="Get Images"></p>
-</form>


### PR DESCRIPTION
## Changes
* Refactor `HttpServer` to v2.
* Add server v2 model structs.
* Add `DownloadManyHandler` controller.
* Refactor `HttpServer` to v2.
  * Add `DownloadManyHandler` endpoint.
  * Add `DownloadAndStoreManyHandler` endpoint.
  * Add `DefaultPatternsHandler` endpoint.
  * Add health endpoint.
* Refactor `cmd` server method.
* Add `go_middlewares` dependency.
* Add `AllowedOrigins` config attribute.
* Add `cors` support to server.
* Update refactor `config.toml`.
