### PR TITLE
fix: 404 download handling

### DIFF
--- a/internal/server/controllers.go
+++ b/internal/server/controllers.go
@@ -3,7 +3,6 @@ package server
 import (
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -57,10 +56,7 @@ func (h *HttpServer) handleDownload(c *gin.Context, useStore bool) {
 
 		if err != nil {
 			log.Println(err.Error())
-			if strings.Contains(err.Error(), "404") {
-				log.Printf("Skipping 404 for URL: %s", url)
-				continue
-			}
+
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
 			return
 		}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -17,7 +17,8 @@ func Target(target model.Target) (model.File, error) {
 		return model.File{}, fmt.Errorf("error making HTTP request to \"%s\": %s", target.URL, err.Error())
 	}
 
-	if response.StatusCode == http.StatusOK {
+	switch response.StatusCode {
+	case http.StatusOK:
 		bodyBytes, err := io.ReadAll(response.Body)
 		if err != nil {
 			return model.File{}, fmt.Errorf("error reading response body: %s", err.Error())
@@ -29,7 +30,7 @@ func Target(target model.Target) (model.File, error) {
 		}
 
 		return file, nil
-	} else if response.StatusCode == http.StatusNotFound {
+	case http.StatusNotFound:
 		log.Printf("File not found for URL: %s\n", target.URL)
 
 		return model.File{}, nil

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -4,6 +4,7 @@ package download
 import (
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/ribeirohugo/go_content_getter/pkg/model"
@@ -28,6 +29,10 @@ func Target(target model.Target) (model.File, error) {
 		}
 
 		return file, nil
+	} else if response.StatusCode == http.StatusNotFound {
+		log.Printf("File not found for URL: %s\n", target.URL)
+
+		return model.File{}, nil
 	}
 
 	return model.File{}, fmt.Errorf("error response status: %s", response.Status)
@@ -42,7 +47,9 @@ func ManyTargets(targets []model.Target) ([]model.File, error) {
 			return files, err
 		}
 
-		files = append(files, file)
+		if file.Filename != "" {
+			files = append(files, file)
+		}
 	}
 
 	return files, nil


### PR DESCRIPTION
## Changes
* Remove 404 error handling from `handleDownload` server method.
* Refactor `download` package methods:
  * update `Target` download method to not return error in `404` error.
  * update `ManyTargets` to ignore empty files.
